### PR TITLE
Expose default client configuration

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors
 ------------
 
 - Dan Sully, `dsully@github <https://github.com/dsully>`_
+- Cooper Benson, `skycoop@github <https://github.com/skycoop>`_

--- a/src/sqlservice/client.py
+++ b/src/sqlservice/client.py
@@ -19,10 +19,11 @@ from . import core
 from .model import declarative_base
 from .query import SQLQuery
 from ._compat import iteritems, string_types
+from .utils import FrozenDict
 
 
 class SQLClient(object):
-    DEFAULT_CONFIG = {
+    DEFAULT_CONFIG = FrozenDict({
         'SQL_DATABASE_URI': 'sqlite://',
         'SQL_ECHO': False,
         'SQL_ECHO_POOL': False,
@@ -37,7 +38,7 @@ class SQLClient(object):
         'SQL_AUTOFLUSH': True,
         'SQL_EXPIRE_ON_COMMIT': True,
         'SQL_POOL_PRE_PING': None
-    }
+    })
 
     """Database client for interacting with a database.
 
@@ -132,7 +133,7 @@ class SQLClient(object):
         self.query_class = query_class
         self.session_class = session_class
 
-        self.config = self.DEFAULT_CONFIG.copy()
+        self.config = self.DEFAULT_CONFIG.dict()
 
         self.config.update(config or {})
 

--- a/src/sqlservice/client.py
+++ b/src/sqlservice/client.py
@@ -22,6 +22,23 @@ from ._compat import iteritems, string_types
 
 
 class SQLClient(object):
+    DEFAULT_CONFIG = {
+        'SQL_DATABASE_URI': 'sqlite://',
+        'SQL_ECHO': False,
+        'SQL_ECHO_POOL': False,
+        'SQL_ENCODING': None,
+        'SQL_CONVERT_UNICODE': None,
+        'SQL_ISOLATION_LEVEL': None,
+        'SQL_POOL_SIZE': None,
+        'SQL_POOL_TIMEOUT': None,
+        'SQL_POOL_RECYCLE': None,
+        'SQL_MAX_OVERFLOW': None,
+        'SQL_AUTOCOMMIT': False,
+        'SQL_AUTOFLUSH': True,
+        'SQL_EXPIRE_ON_COMMIT': True,
+        'SQL_POOL_PRE_PING': None
+    }
+
     """Database client for interacting with a database.
 
     The following configuration values can be passed into a new
@@ -115,22 +132,7 @@ class SQLClient(object):
         self.query_class = query_class
         self.session_class = session_class
 
-        self.config = {
-            'SQL_DATABASE_URI': 'sqlite://',
-            'SQL_ECHO': False,
-            'SQL_ECHO_POOL': False,
-            'SQL_ENCODING': None,
-            'SQL_CONVERT_UNICODE': None,
-            'SQL_ISOLATION_LEVEL': None,
-            'SQL_POOL_SIZE': None,
-            'SQL_POOL_TIMEOUT': None,
-            'SQL_POOL_RECYCLE': None,
-            'SQL_MAX_OVERFLOW': None,
-            'SQL_AUTOCOMMIT': False,
-            'SQL_AUTOFLUSH': True,
-            'SQL_EXPIRE_ON_COMMIT': True,
-            'SQL_POOL_PRE_PING': None
-        }
+        self.config = self.DEFAULT_CONFIG
 
         self.config.update(config or {})
 

--- a/src/sqlservice/client.py
+++ b/src/sqlservice/client.py
@@ -132,7 +132,7 @@ class SQLClient(object):
         self.query_class = query_class
         self.session_class = session_class
 
-        self.config = self.DEFAULT_CONFIG
+        self.config = self.DEFAULT_CONFIG.copy()
 
         self.config.update(config or {})
 

--- a/src/sqlservice/utils.py
+++ b/src/sqlservice/utils.py
@@ -5,10 +5,10 @@ Utilities
 
 The utilities module.
 """
-
+from collections import Mapping
 from functools import wraps
 
-from ._compat import Iterable, string_types
+from ._compat import Iterable, string_types, iteritems
 
 
 def classonce(meth):
@@ -34,3 +34,26 @@ def is_sequence(obj):
     return (isinstance(obj, Iterable) and
             not isinstance(obj, string_types) and
             not isinstance(obj, dict))
+
+
+class FrozenDict(Mapping):
+    def __init__(self, *args, **kwargs):
+        self._dict = dict(*args, **kwargs)
+
+    def dict(self):
+        return self._dict.copy()
+
+    def __getitem__(self, key):
+        return self._dict.__getitem__(key)
+
+    def __contains__(self, item):
+        return self._dict.__contains__(item)
+
+    def __iter__(self):
+        return self._dict.__iter__()
+
+    def __len__(self):
+        return self._dict.__len__()
+
+    def __repr__(self):
+        return '<%s %r>' % (self.__class__.__name__, self._dict)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlservice.utils import FrozenDict
+
+
+def test_frozendict_getitem():
+    frozen_d = FrozenDict({'a': 1})
+    assert frozen_d['a'] == frozen_d._dict['a']
+
+
+def test_frozendict_immutability():
+    frozen_d = FrozenDict()
+    with pytest.raises(TypeError):
+        frozen_d['a'] = 1
+
+
+def test_frozendict_contains():
+    frozen_d = FrozenDict({'a': 1})
+    assert 'a' in frozen_d
+    assert 'b' not in frozen_d
+
+
+def test_frozendict_iter():
+    frozen_d = FrozenDict({'a': 1})
+    assert list(iter(frozen_d)) == list(iter(frozen_d._dict))
+
+
+def test_frozendict_len():
+    frozen_d = FrozenDict({'a': 1})
+    assert len(frozen_d) == len(frozen_d._dict)
+
+
+def test_frozendict_repr():
+    frozen_d = FrozenDict({'a': 1})
+    assert repr(frozen_d) == "<FrozenDict {'a': 1}>"


### PR DESCRIPTION
I moved the default config to a class variable so that users could access it. I personally need this so that I can get a list of the expected configuration values so that I can pull them from the Flask application configuration.