### PR TITLE
Add max depth parameter to be able load nested relationships on a model

### DIFF
--- a/src/sqlservice/model.py
+++ b/src/sqlservice/model.py
@@ -65,8 +65,8 @@ class ModelBase:
     def to_dict(
         self,
         *,
-        exclude_relationships: bool = False,
         lazyload: bool = False,
+        exclude_relationships: bool = False,
         include_nested_relationships: bool = False,
     ) -> t.Dict[str, t.Any]:
         """
@@ -75,10 +75,9 @@ class ModelBase:
         Only the loaded data, i.e. data previously fetched from the database, will be serialized.
         Lazy-loaded columns and relationships will be excluded to avoid extra database queries.
 
-        By default, only table columns will be included. To exclude relationships, set
-        ``exclude_relationships=True``.
-
-        To include nested relationships, set ``include_nested_relationships=True``.
+        By default, table columns and relationships will be included while nested relationships
+        will be excluded. To exclude relationships, set ``exclude_relationships=True``. To
+        include nested relationships, set ``include_nested_relationships=True``.
         """
         serializer = ModelSerializer(
             exclude_relationships=exclude_relationships,
@@ -122,12 +121,12 @@ class ModelSerializer:
     def __init__(
         self,
         *,
-        exclude_relationships: bool = False,
         lazyload: bool = False,
+        exclude_relationships: bool = False,
         include_nested_relationships: bool = False,
     ):
-        self.exclude_relationships = exclude_relationships
         self.lazyload = lazyload
+        self.exclude_relationships = exclude_relationships
         self.include_nested_relationships = include_nested_relationships
 
     def to_dict(self, model: ModelBase) -> t.Dict[str, t.Any]:

--- a/src/sqlservice/model.py
+++ b/src/sqlservice/model.py
@@ -67,7 +67,6 @@ class ModelBase:
         *,
         exclude_relationships: bool = False,
         lazyload: bool = False,
-        exclude_nested_relationships: bool = False,
         include_nested_relationships: bool = False,
     ) -> t.Dict[str, t.Any]:
         """
@@ -76,17 +75,14 @@ class ModelBase:
         Only the loaded data, i.e. data previously fetched from the database, will be serialized.
         Lazy-loaded columns and relationships will be excluded to avoid extra database queries.
 
-        By default, only table columns will be included. To include relationship fields, set
-        ``include_relationships=True``. This will nest ``to_dict()`` calls to the relationship
-        models.
+        By default, only table columns will be included. To exclude relationships, set
+        ``exclude_relationships=True``.
 
-        ``exclude_nested_relationships``: Exclude nested relationships. Defaults to ``False``.
-        ``include_nested_relationships``: Include nested relationships. Defaults to ``False``.
+        To include nested relationships, set ``include_nested_relationships=True``.
         """
         serializer = ModelSerializer(
             exclude_relationships=exclude_relationships,
             lazyload=lazyload,
-            exclude_nested_relationships=exclude_nested_relationships,
             include_nested_relationships=include_nested_relationships,
         )
         return serializer.to_dict(self)
@@ -128,12 +124,10 @@ class ModelSerializer:
         *,
         exclude_relationships: bool = False,
         lazyload: bool = False,
-        exclude_nested_relationships: bool = False,
         include_nested_relationships: bool = False,
     ):
         self.exclude_relationships = exclude_relationships
         self.lazyload = lazyload
-        self.exclude_nested_relationships = exclude_nested_relationships
         self.include_nested_relationships = include_nested_relationships
 
     def to_dict(self, model: ModelBase) -> t.Dict[str, t.Any]:
@@ -172,10 +166,7 @@ class ModelSerializer:
         include_relationships = not self.exclude_relationships
 
         if current_depth > 0:
-            if self.include_nested_relationships:
-                include_relationships = True
-            elif self.exclude_nested_relationships:
-                include_relationships = False
+            include_relationships = self.include_nested_relationships
 
         fields = mapper.columns.keys()
         if include_relationships:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -36,6 +36,21 @@ class Model(ModelBase):
     pass
 
 
+class Book(Model):
+    __tablename__ = "books"
+
+    id: Mapped[int] = mapped_column(sa.Integer(), primary_key=True)
+    title: Mapped[str] = mapped_column(sa.String())
+    created_by: Mapped[int] = mapped_column(sa.Integer(), sa.ForeignKey("users.id"), nullable=False)
+    created_by_user: Mapped["User"] = relationship(
+        "User", foreign_keys=[created_by], back_populates="created_books"
+    )
+    updated_by: Mapped[int] = mapped_column(sa.Integer(), sa.ForeignKey("users.id"), nullable=False)
+    updated_by_user: Mapped["User"] = relationship(
+        "User", foreign_keys=[updated_by], back_populates="updated_books"
+    )
+
+
 class User(Model):
     __tablename__ = "users"
 
@@ -48,6 +63,12 @@ class User(Model):
         "GroupMembership", back_populates="user"
     )
     items: Mapped[t.List["GroupMembership"]] = relationship("Item")
+    created_books: Mapped[t.List["Book"]] = relationship(
+        "Book", foreign_keys=[Book.created_by], back_populates="created_by_user"
+    )
+    updated_books: Mapped[t.List["Book"]] = relationship(
+        "Book", foreign_keys=[Book.updated_by], back_populates="updated_by_user"
+    )
 
 
 class Address(Model):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -247,7 +247,7 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                     GroupMembership(group=Group(name="g2")),
                 ],
             ),
-            {},
+            {"include_nested_relationships": True},
             [orm.joinedload("*")],
             {
                 "id": 1,
@@ -286,7 +286,7 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                     )
                 ],
             ),
-            {"lazyload": True},
+            {"lazyload": True, "include_nested_relationships": True},
             [orm.lazyload("*")],
             {
                 "id": 1,
@@ -339,7 +339,7 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                 created_by_user=User(id=1, name="n"),
                 updated_by_user=User(id=2, name="n"),
             ),
-            {"lazyload": True, "exclude_nested_relationships": True},
+            {"lazyload": True},
             [],
             {
                 "id": 1,
@@ -349,7 +349,24 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                 "created_by_user": {"id": 1, "name": "n", "active": True},
                 "updated_by_user": {"id": 2, "name": "n", "active": True},
             },
-            id="circular_reference_lazy_loaded",
+            id="exclude_nested_relationships_lazy_loaded_with_circular_reference",
+        ),
+        param(
+            Book(
+                id=1,
+                title="t",
+                created_by_user=User(id=1, name="n"),
+                updated_by_user=User(id=2, name="n"),
+            ),
+            {},
+            [],
+            {
+                "id": 1,
+                "title": "t",
+                "created_by": 1,
+                "updated_by": 2,
+            },
+            id="exclude_nested_relationships_with_circular_reference",
         ),
         param(
             Book(
@@ -405,7 +422,7 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                     ],
                 },
             },
-            id="circular_reference_lazy_loaded_with_max_depth",
+            id="include_nested_relationships_lazy_loaded_with_circular_reference",
         ),
     ],
 )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -339,7 +339,7 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                 created_by_user=User(id=1, name="n"),
                 updated_by_user=User(id=2, name="n"),
             ),
-            {"lazyload": True, "max_depth": 1},
+            {"lazyload": True, "exclude_nested_relationships": True},
             [],
             {
                 "id": 1,
@@ -358,7 +358,7 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                 created_by_user=User(id=1, name="n"),
                 updated_by_user=User(id=2, name="n"),
             ),
-            {"lazyload": True, "max_depth": 2},
+            {"lazyload": True, "include_nested_relationships": True},
             [],
             {
                 "id": 1,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import Delete, Insert, Select, Update
 
 from sqlservice import Database, ModelBase, ModelMeta, as_declarative, declarative_base
 
-from .fixtures import Address, Group, GroupMembership, Item, Note, User
+from .fixtures import Address, Book, Group, GroupMembership, Item, Note, User
 
 
 parametrize = pytest.mark.parametrize
@@ -217,6 +217,8 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                 "addresses": [{"id": 1, "user_id": 1, "addr": "a", "zip_code": "1"}],
                 "group_memberships": [],
                 "items": [],
+                "created_books": [],
+                "updated_books": [],
             },
             id="1:M_all_loaded_include_relationships",
         ),
@@ -260,6 +262,8 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                     {"group_id": 2, "user_id": 1, "group": {"id": 2, "name": "g2"}},
                 ],
                 "items": [],
+                "created_books": [],
+                "updated_books": [],
             },
             id="nested_relationships_all_loaded",
         ),
@@ -323,8 +327,85 @@ def test_model_to_dict__with_non_persisted_model(model: ModelBase, args: dict, e
                         },
                     }
                 ],
+                "created_books": [],
+                "updated_books": [],
             },
             id="nested_relationships_lazy_loaded",
+        ),
+        param(
+            Book(
+                id=1,
+                title="t",
+                created_by_user=User(id=1, name="n"),
+                updated_by_user=User(id=2, name="n"),
+            ),
+            {"lazyload": True, "max_depth": 1},
+            [],
+            {
+                "id": 1,
+                "title": "t",
+                "created_by": 1,
+                "updated_by": 2,
+                "created_by_user": {"id": 1, "name": "n", "active": True},
+                "updated_by_user": {"id": 2, "name": "n", "active": True},
+            },
+            id="circular_reference_lazy_loaded",
+        ),
+        param(
+            Book(
+                id=1,
+                title="t",
+                created_by_user=User(id=1, name="n"),
+                updated_by_user=User(id=2, name="n"),
+            ),
+            {"lazyload": True, "max_depth": 2},
+            [],
+            {
+                "id": 1,
+                "title": "t",
+                "created_by": 1,
+                "updated_by": 2,
+                "created_by_user": {
+                    "id": 1,
+                    "name": "n",
+                    "active": True,
+                    "addresses": [],
+                    "group_memberships": [],
+                    "items": [],
+                    "created_books": [{"id": 1, "title": "t", "created_by": 1, "updated_by": 2}],
+                    "updated_books": [],
+                },
+                "updated_by_user": {
+                    "id": 2,
+                    "name": "n",
+                    "active": True,
+                    "addresses": [],
+                    "group_memberships": [],
+                    "items": [],
+                    "created_books": [],
+                    "updated_books": [
+                        {
+                            "id": 1,
+                            "title": "t",
+                            "created_by": 1,
+                            "updated_by": 2,
+                            "created_by_user": {
+                                "id": 1,
+                                "name": "n",
+                                "active": True,
+                                "addresses": [],
+                                "group_memberships": [],
+                                "items": [],
+                                "created_books": [
+                                    {"id": 1, "title": "t", "created_by": 1, "updated_by": 2}
+                                ],
+                                "updated_books": [],
+                            },
+                        }
+                    ],
+                },
+            },
+            id="circular_reference_lazy_loaded_with_max_depth",
         ),
     ],
 )


### PR DESCRIPTION
# Problem
- Right now, `to_dict` method goes into recursion issue whenever we want to load all the nested relationships
- We also have the issue where if we have multiple attribute/relationships with the same model, only one attribute gets loaded with `to_dict` and the other doesn't load as the model is already in `seen` and is not going to be visited again

# Goal
- closes #43 

# Approach Taken
- Introduced a `max_depth` parameter which can help only load relationship upto a certain depth
- I also went ahead and introduced `cache` where we can store the model object based on the `id` value. So, when a model is already visited and if we want it again - we can load it up from the cache